### PR TITLE
Add poetry dependency support, installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 specials.json
 examples.json
+*/__pycache__

--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Features:
 - uses likelihoods instead of raw generations to guide the model's decision-making
 - ability to build a reference set of examples that the LM can make reference to
 - ability to fix the LM's mistakes online and add them to the reference set for future use
+
+## Set up and running instructions
+
+1. Clone this repository and `cd` into its main working directory.
+2. Install [poetry](https://python-poetry.org/docs/#installation)
+3. Install dependencies: `poetry install --no-root`
+4. Set up playwright: `poetry run playwright install`
+5. Run main: `poetry run python -m weblm.main`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "weblm"
+version = "0.1.0"
+description = ""
+authors = ["Aidan Gomez <aidan@secant.ai>"]
+license = "MIT"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+cohere = "^2.6.1"
+numpy = "^1.23.4"
+playwright = "^1.27.1"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
What it says on the tin. After this PR, the project will be supported by poetry such that users can install dependencies from scratch after a git clone with `poetry install --no-root` and run the project with `poetry run python -m weblm.main`. 